### PR TITLE
유저 로그인 API 구현

### DIFF
--- a/backend/timebank/build.gradle.kts
+++ b/backend/timebank/build.gradle.kts
@@ -42,8 +42,11 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    implementation("com.auth0:java-jwt:4.3.0")
 
     runtimeOnly("mysql:mysql-connector-java:8.0.32")
 

--- a/backend/timebank/build.gradle.kts
+++ b/backend/timebank/build.gradle.kts
@@ -1,5 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    dependencies {
+        classpath("io.spring.gradle:dependency-management-plugin:1.1.0")
+    }
+}
+
 plugins {
     id("org.springframework.boot") version "3.0.4"
     id("io.spring.dependency-management") version "1.1.0"
@@ -23,12 +29,21 @@ allOpen {
     annotation("javax.persistence.Embeddable")
 }
 
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2022.0.1")
+    }
+}
+
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     runtimeOnly("mysql:mysql-connector-java:8.0.32")
 

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/TimeBankApplication.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/TimeBankApplication.kt
@@ -1,11 +1,15 @@
 package kookmin.software.capstone2023.timebank
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
 
 @EnableFeignClients
 @SpringBootApplication
+@ConfigurationPropertiesScan(
+    value = ["kookmin.software.capstone2023.timebank.application.configuration"],
+)
 class TimeBankApplication
 
 fun main() {

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/TimeBankApplication.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/TimeBankApplication.kt
@@ -2,7 +2,9 @@ package kookmin.software.capstone2023.timebank
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
+@EnableFeignClients
 @SpringBootApplication
 class TimeBankApplication
 

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AccessTokenProperties.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AccessTokenProperties.kt
@@ -1,0 +1,8 @@
+package kookmin.software.capstone2023.timebank.application.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "auth.access-token")
+data class AccessTokenProperties(
+    val secretKey: String,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/SocialUserFindService.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/SocialUserFindService.kt
@@ -1,0 +1,28 @@
+package kookmin.software.capstone2023.timebank.application.service.auth
+
+import kookmin.software.capstone2023.timebank.domain.model.SocialPlatformType
+import kookmin.software.capstone2023.timebank.infrastructure.client.kakao.KakaoRestClient
+import org.springframework.stereotype.Service
+
+@Service
+class SocialUserFindService(
+    private val kakaoRestClient: KakaoRestClient,
+) {
+    data class SocialUser(
+        val id: String,
+    )
+
+    fun getSocialUser(platformType: SocialPlatformType, accessToken: String): SocialUser {
+        when (platformType) {
+            SocialPlatformType.KAKAO -> {
+                val kakaoUser = kakaoRestClient.getUserInfo(
+                    authorization = "Bearer $accessToken"
+                )
+
+                return SocialUser(
+                    id = kakaoUser.id.toString(),
+                )
+            }
+        }
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/UserLoginService.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/UserLoginService.kt
@@ -1,0 +1,52 @@
+package kookmin.software.capstone2023.timebank.application.service.auth
+
+import kookmin.software.capstone2023.timebank.application.exception.UnauthorizedException
+import kookmin.software.capstone2023.timebank.application.service.auth.token.UserAccessTokenIssueService
+import kookmin.software.capstone2023.timebank.domain.model.SocialPlatformType
+import kookmin.software.capstone2023.timebank.domain.model.User
+import kookmin.software.capstone2023.timebank.domain.repository.UserJpaRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@Service
+class UserLoginService(
+    private val socialUserFindService: SocialUserFindService,
+    private val userAccessTokenIssueService: UserAccessTokenIssueService,
+    private val userJpaRepository: UserJpaRepository,
+) {
+    data class UserLoginData(
+        val accessToken: String,
+    )
+
+    @Transactional
+    fun socialLogin(
+        provider: SocialPlatformType,
+        accessToken: String
+    ): UserLoginData {
+        val socialUser = socialUserFindService.getSocialUser(
+            platformType = provider,
+            accessToken = accessToken,
+        )
+
+        val user: User = userJpaRepository.findBySocialLoginProviderAndSocialUserId(
+            socialLoginProvider = provider,
+            socialUserId = socialUser.id,
+        ) ?: throw UnauthorizedException(message = "등록되지 않은 사용자입니다.")
+
+        val userAccessToken = userAccessTokenIssueService.issue(
+            userId = user.id,
+            expiresAt = Instant.now().plus(7, ChronoUnit.DAYS),
+        )
+
+        user.updateLastLoginAt(
+            loginAt = LocalDateTime.now(),
+        )
+
+        return UserLoginData(
+            accessToken = userAccessToken,
+        )
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/UserAccessTokenIssueService.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/UserAccessTokenIssueService.kt
@@ -1,0 +1,21 @@
+package kookmin.software.capstone2023.timebank.application.service.auth.token
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import kookmin.software.capstone2023.timebank.application.configuration.AccessTokenProperties
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class UserAccessTokenIssueService(
+    private val accessTokenProperties: AccessTokenProperties,
+) {
+    fun issue(userId: Long, expiresAt: Instant): String {
+        val signAlgorithm = Algorithm.HMAC256(accessTokenProperties.secretKey)
+
+        return JWT.create()
+            .withClaim("userId", userId)
+            .withExpiresAt(expiresAt)
+            .sign(signAlgorithm)
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/Account.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/Account.kt
@@ -1,0 +1,14 @@
+package kookmin.software.capstone2023.timebank.domain.model
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "account")
+class Account(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Embedded
+    var profile: AccountProfile,
+): BaseTimeEntity()

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/AccountProfile.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/AccountProfile.kt
@@ -1,0 +1,19 @@
+package kookmin.software.capstone2023.timebank.domain.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class AccountProfile(
+    /**
+     * 닉네임
+     */
+    @Column(nullable = true, updatable = true, length = 20)
+    var nickname: String,
+
+    /**
+     * 프로필 이미지 URL
+     */
+    @Column(nullable = true, updatable = true, length = 100)
+    var imageUrl: String,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/BaseTimeEntity.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/BaseTimeEntity.kt
@@ -1,0 +1,27 @@
+package kookmin.software.capstone2023.timebank.domain.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+open class BaseTimeEntity(
+    /**
+     * 생성 시간 (UTC)
+     */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.MIN,
+
+    /**
+     * 마지막 수정 시간 (UTC)
+     */
+    @LastModifiedDate
+    @Column(nullable = false, updatable = true)
+    var updatedAt: LocalDateTime = LocalDateTime.MIN,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/SocialPlatformType.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/SocialPlatformType.kt
@@ -1,0 +1,5 @@
+package kookmin.software.capstone2023.timebank.domain.model
+
+enum class SocialPlatformType {
+    KAKAO,
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/User.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/User.kt
@@ -1,0 +1,41 @@
+package kookmin.software.capstone2023.timebank.domain.model
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "user")
+class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    /**
+     * 계정 ID
+     */
+    @Column(nullable = false, updatable = true)
+    val accountId: Long,
+
+    /**
+     * 소셜 로그인 제공자
+     */
+    @Column(nullable = true, updatable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    val socialLoginProvider: SocialPlatformType?,
+
+    /**
+     * 소셜 플랫폼 유저 ID
+     */
+    @Column(nullable = true, updatable = false, length = 20)
+    val socialUserId: String?,
+
+    /**
+     * 마지막 로그인 시간 (UTC)
+     */
+    @Column(nullable = true, updatable = true)
+    var lastLoginAt: LocalDateTime?,
+) : BaseTimeEntity() {
+    fun updateLastLoginAt(loginAt: LocalDateTime) {
+        this.lastLoginAt = loginAt
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/repository/UserJpaRepository.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/repository/UserJpaRepository.kt
@@ -1,0 +1,11 @@
+package kookmin.software.capstone2023.timebank.domain.repository
+
+import kookmin.software.capstone2023.timebank.domain.model.SocialPlatformType
+import kookmin.software.capstone2023.timebank.domain.model.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserJpaRepository : JpaRepository<User, Long> {
+    fun findBySocialLoginProviderAndSocialUserId(socialLoginProvider: SocialPlatformType, socialUserId: String): User?
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/FeignConfiguration.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/FeignConfiguration.kt
@@ -1,0 +1,12 @@
+package kookmin.software.capstone2023.timebank.infrastructure.client
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
+
+class FeignConfiguration {
+    @Bean
+    @Profile("dev")
+    fun feignLoggerLevel(): feign.Logger.Level {
+        return feign.Logger.Level.FULL
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/KakaoRestClient.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/KakaoRestClient.kt
@@ -1,0 +1,19 @@
+package kookmin.software.capstone2023.timebank.infrastructure.client.kakao
+
+import kookmin.software.capstone2023.timebank.infrastructure.client.FeignConfiguration
+import kookmin.software.capstone2023.timebank.infrastructure.client.kakao.model.GetUserInfoResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(
+    name = "kakaoRestFeignClient",
+    url = "https://kapi.kakao.com",
+    configuration = [FeignConfiguration::class]
+)
+interface KakaoRestClient {
+    @GetMapping("/v2/user/me")
+    fun getUserInfo(
+        @RequestHeader("Authorization") authorization: String,
+    ): GetUserInfoResponse
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/GetUserInfoResponse.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/GetUserInfoResponse.kt
@@ -1,0 +1,20 @@
+package kookmin.software.capstone2023.timebank.infrastructure.client.kakao.model
+
+import java.time.LocalDateTime
+
+data class GetUserInfoResponse(
+    /**
+     * 회원번호
+     */
+    val id: Long,
+
+    /**
+     * 카카오계정 정보
+     */
+    val kakaoAccount: KakaoAccount?,
+
+    /**
+     * 서비스 연결일시 (UTC)
+     */
+    val connectedAt: LocalDateTime?,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/KakaoAccount.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/KakaoAccount.kt
@@ -1,0 +1,7 @@
+package kookmin.software.capstone2023.timebank.infrastructure.client.kakao.model
+
+data class KakaoAccount(
+    val profileNicknameNeedsAgreement: Boolean?,
+    val profileImageNeedsAgreement: Boolean?,
+    val profile: KakaoAccountProfile?,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/KakaoAccountProfile.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/client/kakao/model/KakaoAccountProfile.kt
@@ -1,0 +1,38 @@
+package kookmin.software.capstone2023.timebank.infrastructure.client.kakao.model
+
+data class KakaoAccountProfile(
+    /**
+     * 닉네임
+     *
+     * 필요한 동의 항목: 프로필 정보(닉네임/프로필 사진) 또는 닉네임
+     */
+    val nickname: String?,
+
+    /**
+     * 프로필 이미지 URL
+     * 640px * 640px 또는 480px * 480px
+     *
+     * 필요한 동의 항목: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+     *
+     */
+    val profileImageUrl: String?,
+
+    /**
+     * 프로필 미리보기 이미지 URL
+     * 110px * 110px 또는 100px * 100px
+     *
+     * 필요한 동의 항목: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+     */
+    val thumbnailImageUrl: String?,
+
+    /**
+     * 프로필 사진 URL이 기본 프로필 사진 URL인지 여부
+     *
+     * 사용자가 등록한 프로필 사진이 없을 경우, 기본 프로필 사진 제공
+     * true: 기본 프로필 사진
+     * false: 사용자가 등록한 프로필 사진
+     *
+     * 필요한 동의 항목: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+     */
+    val isDefaultImage: Boolean?,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/exception/GlobalExceptionHandler.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package kookmin.software.capstone2023.timebank.presentation.api.exception
 
+import jakarta.validation.ConstraintViolationException
 import kookmin.software.capstone2023.timebank.application.exception.*
 import kookmin.software.capstone2023.timebank.core.logger
 import kookmin.software.capstone2023.timebank.presentation.api.model.ErrorResponse
@@ -40,6 +41,17 @@ class GlobalExceptionHandler {
                 ErrorResponse(
                     code = ApplicationErrorCode.BAD_REQUEST.value,
                     message = e.bindingResult.allErrors.firstOrNull()?.defaultMessage
+                )
+            )
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                ErrorResponse(
+                    code = ApplicationErrorCode.BAD_REQUEST.value,
+                    message = e.constraintViolations.firstOrNull()?.message
                 )
             )
     }

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/AuthController.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/AuthController.kt
@@ -1,0 +1,30 @@
+package kookmin.software.capstone2023.timebank.presentation.api.v1
+
+import kookmin.software.capstone2023.timebank.application.service.auth.UserLoginService
+import kookmin.software.capstone2023.timebank.presentation.api.v1.model.LoginUserRequestData
+import kookmin.software.capstone2023.timebank.presentation.api.v1.model.LoginUserResponseData
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/v1/auth")
+class AuthController(
+    private val userLoginService: UserLoginService,
+) {
+    @PostMapping("login")
+    fun loginUser(
+        @Validated @RequestBody data: LoginUserRequestData.SocialLoginUserRequestData,
+    ): LoginUserResponseData {
+        val loginData = userLoginService.socialLogin(
+            provider = data.provider,
+            accessToken = data.accessToken,
+        )
+
+        return LoginUserResponseData(
+            accessToken = loginData.accessToken,
+        )
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserRequestData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserRequestData.kt
@@ -1,0 +1,13 @@
+package kookmin.software.capstone2023.timebank.presentation.api.v1.model
+
+import jakarta.validation.constraints.NotBlank
+import kookmin.software.capstone2023.timebank.domain.model.SocialPlatformType
+
+sealed class LoginUserRequestData {
+    data class SocialLoginUserRequestData(
+        @field:NotBlank
+        val provider: SocialPlatformType,
+        @field:NotBlank
+        val accessToken: String,
+    ) : LoginUserRequestData()
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserRequestData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserRequestData.kt
@@ -5,9 +5,8 @@ import kookmin.software.capstone2023.timebank.domain.model.SocialPlatformType
 
 sealed class LoginUserRequestData {
     data class SocialLoginUserRequestData(
-        @field:NotBlank
         val provider: SocialPlatformType,
-        @field:NotBlank
+        @field:NotBlank(message = "액세스 토큰은 필수입니다.")
         val accessToken: String,
     ) : LoginUserRequestData()
 }

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserResponseData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/LoginUserResponseData.kt
@@ -1,0 +1,5 @@
+package kookmin.software.capstone2023.timebank.presentation.api.v1.model
+
+data class LoginUserResponseData(
+    val accessToken: String,
+)

--- a/backend/timebank/src/main/resources/application-dev.yml
+++ b/backend/timebank/src/main/resources/application-dev.yml
@@ -9,3 +9,6 @@ spring:
       ddl-auto: update
     open-in-view: false
     show-sql: true
+
+logging.level:
+  kookmin.software.capstone2023.timebank.infrastructure.client.kakao.KakaoRestClient: DEBUG

--- a/backend/timebank/src/main/resources/application-dev.yml
+++ b/backend/timebank/src/main/resources/application-dev.yml
@@ -4,3 +4,8 @@ spring:
     username: timebank
     password: timebank
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    show-sql: true

--- a/backend/timebank/src/main/resources/application-dev.yml
+++ b/backend/timebank/src/main/resources/application-dev.yml
@@ -12,3 +12,7 @@ spring:
 
 logging.level:
   kookmin.software.capstone2023.timebank.infrastructure.client.kakao.KakaoRestClient: DEBUG
+
+auth:
+  access-token:
+    secret-key: 12345678901234567890123456789012


### PR DESCRIPTION
유저 로그인 API을 구현했습니다.
나중에 카카오 이외의 구글, 페이스북 등 다양한 계정으로도 로그인할 수 있도록 설계했어요.

로그인 과정은 아래와 같습니다.
1. 웹뷰에서 카카오 SDK를 통해 로그인 진행 후 카카오 인증 토큰 취득
2. 서버에 플랫폼 종류와 액세스 토큰을 전달해서 로그인 요청
3. 서버는 OpenFeign으로 카카오 유저 정보 조회 API 조회
4. 시간은행 유저 ID를 담아서 액세스 토큰 발급 (JWT)