### PR TITLE
유저 인증

### DIFF
--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AccessTokenProperties.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AccessTokenProperties.kt
@@ -2,7 +2,7 @@ package kookmin.software.capstone2023.timebank.application.configuration
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties(prefix = "auth.access-token")
+@ConfigurationProperties(prefix = "application.authentication.access-token")
 data class AccessTokenProperties(
     val secretKey: String,
 )

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AuthenticationTestProperties.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/AuthenticationTestProperties.kt
@@ -1,0 +1,12 @@
+package kookmin.software.capstone2023.timebank.application.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+
+@ConfigurationProperties(prefix = "application.authentication.test")
+data class AuthenticationTestProperties(
+    val enabled: Boolean,
+    val userId: Long,
+    val accountId: Long,
+    val accountType: String,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/UserAuthenticatorConfiguration.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/configuration/UserAuthenticatorConfiguration.kt
@@ -1,0 +1,66 @@
+package kookmin.software.capstone2023.timebank.application.configuration
+
+import kookmin.software.capstone2023.timebank.application.service.auth.DefaultUserAuthenticator
+import kookmin.software.capstone2023.timebank.application.service.auth.TestEnvironmentUserAuthenticator
+import kookmin.software.capstone2023.timebank.application.service.auth.UserAuthenticator
+import kookmin.software.capstone2023.timebank.application.service.auth.token.AccessTokenService
+import kookmin.software.capstone2023.timebank.core.logger
+import kookmin.software.capstone2023.timebank.domain.model.AccountType
+import kookmin.software.capstone2023.timebank.domain.repository.AccountJpaRepository
+import kookmin.software.capstone2023.timebank.domain.repository.UserJpaRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+class UserAuthenticatorConfiguration(
+    private val authenticationTestProperties: AuthenticationTestProperties,
+) {
+    private val logger by logger()
+
+    @Bean
+    @Profile("dev")
+    fun devEnvironmentUserAuthenticator(
+        accessTokenService: AccessTokenService,
+        userJpaRepository: UserJpaRepository,
+        accountJpaRepository: AccountJpaRepository,
+    ): UserAuthenticator {
+        // 인증 테스트가 활성화되어 있으면 테스트 환경 사용자 인증기를 반환한다.
+        if (authenticationTestProperties.enabled) {
+            val accountType = AccountType.valueOf(authenticationTestProperties.accountType)
+
+            logger.info("Test environment user authenticator is enabled.")
+            logger.info("userId: ${authenticationTestProperties.userId}")
+            logger.info("accountId: ${authenticationTestProperties.accountId}")
+            logger.info("accountType: $accountType")
+
+            return TestEnvironmentUserAuthenticator(
+                userId = authenticationTestProperties.userId,
+                accountId = authenticationTestProperties.accountId,
+                accountType = accountType,
+            )
+        }
+
+        logger.info("Test environment user authenticator is disabled. (default user authenticator is enabled.")
+
+        return DefaultUserAuthenticator(
+            accessTokenService = accessTokenService,
+            userJpaRepository = userJpaRepository,
+            accountJpaRepository = accountJpaRepository,
+        )
+    }
+
+    @Bean
+    @Profile("!dev")
+    fun defaultUserAuthenticator(
+        accessTokenService: AccessTokenService,
+        userJpaRepository: UserJpaRepository,
+        accountJpaRepository: AccountJpaRepository,
+    ): UserAuthenticator {
+        return DefaultUserAuthenticator(
+            accessTokenService = accessTokenService,
+            userJpaRepository = userJpaRepository,
+            accountJpaRepository = accountJpaRepository,
+        )
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/DefaultUserAuthenticator.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/DefaultUserAuthenticator.kt
@@ -1,0 +1,33 @@
+package kookmin.software.capstone2023.timebank.application.service.auth
+
+import kookmin.software.capstone2023.timebank.application.exception.UnauthorizedException
+import kookmin.software.capstone2023.timebank.application.service.auth.token.AccessTokenService
+import kookmin.software.capstone2023.timebank.domain.repository.AccountJpaRepository
+import kookmin.software.capstone2023.timebank.domain.repository.UserJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+class DefaultUserAuthenticator(
+    private val accessTokenService: AccessTokenService,
+    private val userJpaRepository: UserJpaRepository,
+    private val accountJpaRepository: AccountJpaRepository,
+) : UserAuthenticator {
+    override fun authenticate(accessToken: String): UserAuthenticator.AuthenticationData {
+        val claims = accessTokenService.verify(accessToken)
+
+        val user = userJpaRepository.findByIdOrNull(claims.userId)
+            ?: throw UnauthorizedException(message = null)
+
+        val account = accountJpaRepository.findByIdOrNull(claims.accountId)
+            ?: throw UnauthorizedException(message = null)
+
+        if (user.accountId != account.id) {
+            throw UnauthorizedException(message = null)
+        }
+
+        return UserAuthenticator.AuthenticationData(
+            userId = user.id,
+            accountId = account.id,
+            accountType = account.type,
+        )
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/TestEnvironmentUserAuthenticator.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/TestEnvironmentUserAuthenticator.kt
@@ -1,0 +1,17 @@
+package kookmin.software.capstone2023.timebank.application.service.auth
+
+import kookmin.software.capstone2023.timebank.domain.model.AccountType
+
+class TestEnvironmentUserAuthenticator(
+    private val userId: Long,
+    private val accountId: Long,
+    private val accountType: AccountType,
+) : UserAuthenticator {
+    override fun authenticate(accessToken: String): UserAuthenticator.AuthenticationData {
+        return UserAuthenticator.AuthenticationData(
+            userId = userId,
+            accountId = accountId,
+            accountType = accountType,
+        )
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/UserAuthenticator.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/UserAuthenticator.kt
@@ -1,0 +1,13 @@
+package kookmin.software.capstone2023.timebank.application.service.auth
+
+import kookmin.software.capstone2023.timebank.domain.model.AccountType
+
+interface UserAuthenticator {
+    data class AuthenticationData(
+        val userId: Long,
+        val accountId: Long,
+        val accountType: AccountType,
+    )
+
+    fun authenticate(accessToken: String): AuthenticationData
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/model/PasswordAuthenticationRequest.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/model/PasswordAuthenticationRequest.kt
@@ -1,6 +1,0 @@
-package kookmin.software.capstone2023.timebank.application.service.auth.model
-
-data class PasswordAuthenticationRequest(
-    val username: String,
-    val password: String,
-)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/model/SocialAuthenticationRequest.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/model/SocialAuthenticationRequest.kt
@@ -1,8 +1,0 @@
-package kookmin.software.capstone2023.timebank.application.service.auth.model
-
-import kookmin.software.capstone2023.timebank.domain.model.auth.SocialPlatformType
-
-data class SocialAuthenticationRequest(
-    val socialPlatformType: SocialPlatformType,
-    val accessToken: String,
-)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/AccessTokenException.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/AccessTokenException.kt
@@ -1,0 +1,16 @@
+package kookmin.software.capstone2023.timebank.application.service.auth.token
+
+import kookmin.software.capstone2023.timebank.application.exception.ApplicationErrorCode
+import kookmin.software.capstone2023.timebank.application.exception.ApplicationException
+
+sealed class AccessTokenException {
+    class InvalidTokenException : ApplicationException(
+        code = ApplicationErrorCode.UNAUTHORIZED,
+        message = "유효하지 않은 토큰입니다.",
+    )
+
+    class TokenExpiredException : ApplicationException(
+        code = ApplicationErrorCode.UNAUTHORIZED,
+        message = "만료된 토큰입니다.",
+    )
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/AccessTokenService.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/application/service/auth/token/AccessTokenService.kt
@@ -2,6 +2,7 @@ package kookmin.software.capstone2023.timebank.application.service.auth.token
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.TokenExpiredException
 import kookmin.software.capstone2023.timebank.application.configuration.AccessTokenProperties
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -22,5 +23,27 @@ class AccessTokenService(
         }
 
         return tokenBuilder.sign(algorithm)
+    }
+
+    data class AccessTokenClaims(
+        val userId: Long,
+        val accountId: Long,
+    )
+
+    fun verify(token: String): AccessTokenClaims {
+        val algorithm = Algorithm.HMAC256(accessTokenProperties.secretKey)
+        val verifier = JWT.require(algorithm).build()
+        val decodedToken = try {
+            verifier.verify(token)
+        } catch (e: TokenExpiredException) {
+            throw AccessTokenException.TokenExpiredException()
+        } catch (e: Exception) {
+            throw AccessTokenException.InvalidTokenException()
+        }
+
+        return AccessTokenClaims(
+            userId = decodedToken.getClaim("userId").asLong(),
+            accountId = decodedToken.getClaim("accountId").asLong(),
+        )
     }
 }

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/BaseTimeEntity.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/BaseTimeEntity.kt
@@ -16,12 +16,12 @@ open class BaseTimeEntity(
      */
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    var createdAt: LocalDateTime = LocalDateTime.MIN,
+    var createdAt: LocalDateTime = LocalDateTime.now(),
 
     /**
      * 마지막 수정 시간 (UTC)
      */
     @LastModifiedDate
     @Column(nullable = false, updatable = true)
-    var updatedAt: LocalDateTime = LocalDateTime.MIN,
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/RequestAttributes.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/RequestAttributes.kt
@@ -1,0 +1,5 @@
+package kookmin.software.capstone2023.timebank.presentation.api
+
+object RequestAttributes {
+    const val USER_CONTEXT = "userContext"
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/interceptor/UserAuthenticationInterceptor.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/interceptor/UserAuthenticationInterceptor.kt
@@ -1,0 +1,88 @@
+package kookmin.software.capstone2023.timebank.presentation.api.auth.interceptor
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kookmin.software.capstone2023.timebank.application.exception.UnauthorizedException
+import kookmin.software.capstone2023.timebank.application.service.auth.token.AccessTokenService
+import kookmin.software.capstone2023.timebank.domain.repository.AccountJpaRepository
+import kookmin.software.capstone2023.timebank.domain.repository.UserJpaRepository
+import kookmin.software.capstone2023.timebank.presentation.api.RequestAttributes
+import kookmin.software.capstone2023.timebank.presentation.api.auth.model.UserContext
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * 사용자 인증을 처리하는 인터셉터입니다.
+ */
+@Component
+class UserAuthenticationInterceptor(
+    private val accessTokenService: AccessTokenService,
+    private val userJpaRepository: UserJpaRepository,
+    private val accountJpaRepository: AccountJpaRepository,
+) : HandlerInterceptor {
+    /**
+     * 사용자 인증을 처리합니다.
+     *
+     * @param request HttpServletRequest
+     * @param response HttpServletResponse
+     * @param handler HandlerMethod
+     * @return Boolean
+     * @throws UnauthorizedException
+     */
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (handler !is HandlerMethod) {
+            return super.preHandle(request, response, handler)
+        }
+
+        if (request.getAttribute(RequestAttributes.USER_CONTEXT) != null) {
+            return super.preHandle(request, response, handler)
+        }
+
+        val token = getAuthorizationToken(request)
+            ?: return true
+
+        val tokenClaims = accessTokenService.verify(token)
+
+        val user = userJpaRepository.findByIdOrNull(tokenClaims.userId)
+            ?: throw UnauthorizedException(message = null)
+
+        val account = accountJpaRepository.findByIdOrNull(tokenClaims.accountId)
+            ?: throw UnauthorizedException(message = null)
+
+        if (user.accountId != account.id) {
+            throw UnauthorizedException(message = null)
+        }
+
+        val userContext = UserContext(
+            userId = user.id,
+            accountId = account.id,
+            accountType = account.type,
+        )
+
+        request.setAttribute(RequestAttributes.USER_CONTEXT, userContext)
+
+        return true
+    }
+
+    /**
+     * Authorization 헤더에서 토큰을 추출합니다.
+     *
+     * @param request HttpServletRequest
+     * @return 토큰
+     */
+    private fun getAuthorizationToken(request: HttpServletRequest): String? {
+        val authorizationHeader = request.getHeader(AUTHORIZATION_HEADER)
+        return if (authorizationHeader != null && authorizationHeader.startsWith(BEARER_PREFIX)) {
+            authorizationHeader.substring(BEARER_PREFIX.length)
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        const val AUTHORIZATION_HEADER = "Authorization"
+        const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/model/UserAuthentication.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/model/UserAuthentication.kt
@@ -1,0 +1,4 @@
+package kookmin.software.capstone2023.timebank.presentation.api.auth.model
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class UserAuthentication

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/model/UserContext.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/auth/model/UserContext.kt
@@ -1,0 +1,10 @@
+package kookmin.software.capstone2023.timebank.presentation.api.auth.model
+
+import kookmin.software.capstone2023.timebank.domain.model.AccountType
+
+data class UserContext(
+    val userId: Long,
+    val accountId: Long,
+    val accountType: AccountType,
+) {
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/configuration/WebMvcConfiguration.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/configuration/WebMvcConfiguration.kt
@@ -1,0 +1,29 @@
+package kookmin.software.capstone2023.timebank.presentation.api.configuration
+
+import kookmin.software.capstone2023.timebank.presentation.api.auth.interceptor.UserAuthenticationInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfiguration(
+    private val userAuthenticationInterceptor: UserAuthenticationInterceptor,
+): WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(userAuthenticationInterceptor)
+            .addPathPatterns("/api/**")
+    }
+
+    /**
+     * CORS 설정
+     *
+     * 개발 환경이라 전체 허용하지만 실제 서비스에서는 필요한 도메인만 허용하는 것이 좋아요.
+     */
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedMethods("*")
+            .allowedHeaders("*")
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/UserRegisterRequestData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/UserRegisterRequestData.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import kookmin.software.capstone2023.timebank.application.service.auth.model.AuthenticationRequest
 import kookmin.software.capstone2023.timebank.domain.model.auth.SocialPlatformType
+import org.hibernate.validator.constraints.Length
 
 sealed class UserRegisterRequestData {
     data class SocialUserRegisterRequestData(
@@ -14,7 +15,7 @@ sealed class UserRegisterRequestData {
         val accessToken: String,
 
         @field:NotBlank(message = "이름을 입력해주세요.")
-        @field:Max(value = 20, message = "이름은 20자 이하로 입력해주세요.")
+        @field:Length(max = 20, message = "이름은 20자 이하로 입력해주세요.")
         val name: String,
 
         @field:NotBlank(message = "전화번호를 입력해주세요.")
@@ -35,7 +36,7 @@ sealed class UserRegisterRequestData {
         val password: String,
 
         @field:NotBlank(message = "이름을 입력해주세요.")
-        @field:Max(value = 20, message = "이름은 20자 이하로 입력해주세요.")
+        @field:Length(max = 20, message = "이름은 20자 이하로 입력해주세요.")
         val name: String,
 
         @field:NotBlank(message = "전화번호를 입력해주세요.")

--- a/backend/timebank/src/main/resources/application-dev.yml
+++ b/backend/timebank/src/main/resources/application-dev.yml
@@ -13,6 +13,13 @@ spring:
 logging.level:
   kookmin.software.capstone2023.timebank.infrastructure.client.kakao.KakaoRestClient: DEBUG
 
-auth:
-  access-token:
-    secret-key: 12345678901234567890123456789012
+application:
+  authentication:
+    access-token:
+      secret-key: 12345678901234567890123456789012
+
+    test:
+      enabled: ${AUTH_TEST_ENABLED}
+      user-id: ${AUTH_TEST_USER_ID}
+      account-id: ${AUTH_TEST_ACCOUNT_ID}
+      account-type: ${AUTH_TEST_ACCOUNT_TYPE}


### PR DESCRIPTION
- 컨틀롤러에서 유저 인증을 할 수 있도록 작업했어요.
- 인터셉터를 통해 HTTP 요청에 인증 헤더를 파싱하고 유저를 인증하도록 구현했어요.
- 인터셉터를 통과하지 못하면 컨트롤러에 요청이 전달되지 않고 401 UNAUTHORIZED를 클라이언트에게 응답해요.

아래와 같이 인증을 사용할 수 있어요.
```kotlin
@UserAuthentication // 유저 인증이 필요하다는 것을 정의함
@RequestMapping("api/v1/test")
@RestController
class TestController {
    @GetMapping
    fun index(
        @RequestAttribute(RequestAttributes.USER_CONTEXT) userContext: UserContext, // 유저 인증을 통해 유저 정보를 전달해줌
    ) {
        val userId = userContext.userId // 유저 ID
        val accountId = userContext.accountId // 계정 ID
        
        TODO()
    }
}
```