### PR TITLE
은행 계좌 비밀번호 검증 API 추가

### DIFF
--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/security/FailedAttempts.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/model/security/FailedAttempts.kt
@@ -1,0 +1,13 @@
+package kookmin.software.capstone2023.timebank.domain.model.security
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "failed_attempts")
+class FailedAttempts(
+    @Id
+    val ipAddress: String,
+    var attempts: Int = 0,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/repository/security/FailedAttemptsRepository.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/domain/repository/security/FailedAttemptsRepository.kt
@@ -1,0 +1,8 @@
+package kookmin.software.capstone2023.timebank.domain.repository.security
+
+import kookmin.software.capstone2023.timebank.domain.model.security.FailedAttempts
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FailedAttemptsRepository : JpaRepository<FailedAttempts, String> {
+    fun findByIpAddress(ipAddress: String): FailedAttempts?
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/security/FailedAttemptsCounter.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/infrastructure/security/FailedAttemptsCounter.kt
@@ -1,0 +1,28 @@
+package kookmin.software.capstone2023.timebank.infrastructure.security
+import kookmin.software.capstone2023.timebank.domain.model.security.FailedAttempts
+import kookmin.software.capstone2023.timebank.domain.repository.security.FailedAttemptsRepository
+import org.springframework.stereotype.Component
+
+@Component
+class FailedAttemptsCounter(
+    private val failedAttemptsRepository: FailedAttemptsRepository,
+) {
+    fun incrementFailedAttempts(ipAddress: String) {
+        val failedAttempts = failedAttemptsRepository.findByIpAddress(ipAddress)
+        if (failedAttempts != null) {
+            failedAttempts.attempts++
+            failedAttemptsRepository.save(failedAttempts)
+        } else {
+            failedAttemptsRepository.save(FailedAttempts(ipAddress, 1))
+        }
+    }
+
+    fun getFailedAttempts(ipAddress: String): Int {
+        val failedAttempts = failedAttemptsRepository.findByIpAddress(ipAddress)
+        return failedAttempts?.attempts ?: 0
+    }
+
+    fun resetFailedAttempts(ipAddress: String) {
+        failedAttemptsRepository.deleteById(ipAddress)
+    }
+}

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/bank/account/PasswordVerificationRequestData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/bank/account/PasswordVerificationRequestData.kt
@@ -1,0 +1,11 @@
+package kookmin.software.capstone2023.timebank.presentation.api.v1.model.bank.account
+
+import jakarta.validation.constraints.NotBlank
+data class PasswordVerificationRequestData(
+
+    @field:NotBlank(message = "은행 계좌 번호를 보내주세요")
+    val bankAccountNumber: String,
+
+    @field:NotBlank(message = "은행 계좌 패스워드를 보내주세요")
+    val password: String,
+)

--- a/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/bank/account/PasswordVerificationResponseData.kt
+++ b/backend/timebank/src/main/kotlin/kookmin/software/capstone2023/timebank/presentation/api/v1/model/bank/account/PasswordVerificationResponseData.kt
@@ -1,0 +1,6 @@
+package kookmin.software.capstone2023.timebank.presentation.api.v1.model.bank.account
+
+data class PasswordVerificationResponseData(
+    val resResultDesc: String,
+    val resResultCode: String,
+)


### PR DESCRIPTION
비밀번호 검증 API 작업을 진행했습니다.

응답으로는 동일 클라이언트에서 비밀번호 검증 실패한 횟수와 응답 코드(성공한 경우 "1", 실패한 경우 "0") 를 반환합니다